### PR TITLE
feat: implement shadow model training

### DIFF
--- a/build_utils.py
+++ b/build_utils.py
@@ -1,5 +1,4 @@
 import torch
-import numpy as np
 import transformers
 from transformers import get_scheduler
 

--- a/build_utils.py
+++ b/build_utils.py
@@ -1,4 +1,5 @@
 import torch
+import numpy as np
 import transformers
 from transformers import get_scheduler
 
@@ -57,6 +58,45 @@ def build_dataset(config, split, client_id=None, use_h5_images=False, **kwargs):
 
         dataset = PFL_DocVQA(config.imdb_dir, img_dir, split, dataset_kwargs,
                              h5_img_path=h5_img_path, **kwargs)
+
+    else:
+        raise ValueError
+
+    return dataset
+
+def build_dataset_of_subset_of_providers(config, split, provider2doc, list_of_providers, client_id=None, use_h5_images=False, **kwargs):
+    """
+    This function builds a dataset for a subset of providers.
+    """
+
+    # Specify special params for data processing depending on the model used.
+    dataset_kwargs = {}
+
+    if config.model_name.lower() in ['vt5']:
+        dataset_kwargs['get_raw_ocr_data'] = True
+
+    if config.model_name.lower() in ['vt5']:
+        dataset_kwargs['use_images'] = True
+
+    if client_id:
+        dataset_kwargs['client_id'] = client_id
+
+    h5_img_path = config.images_h5_path if use_h5_images else None
+    img_dir = config.images_dir if hasattr(config, 'images_dir') else None
+
+    # Build dataset by looping through all providers
+    # and collecting the indexes of the documents for each provider
+    list_of_indicies = []
+    for provider in list_of_providers:
+        provider_indexes = provider2doc[provider]
+        list_of_indicies.extend(provider_indexes)
+    
+
+    assert 0 not in list_of_indicies
+    if 'DocVQA' in config.dataset_name:
+        from datasets.PFL_DocVQA import PFL_DocVQA
+        dataset = PFL_DocVQA(config.imdb_dir, img_dir, split, dataset_kwargs,
+            list_of_indicies, h5_img_path=h5_img_path, **kwargs)
 
     else:
         raise ValueError

--- a/train.py
+++ b/train.py
@@ -201,8 +201,8 @@ def main():
 
     if config.use_h5:
         # check if h5 image directory exists, and if not, create it:
-        if not os.path.exists(config.h5_images_path):
-            print(f'Requested h5 image path but path does not exist, so performing first-time setup and serialising to: {config.h5_images_path}')
+        if not os.path.exists(config.images_h5_path):
+            print(f'Requested h5 image path but path does not exist, so performing first-time setup and serialising to: {config.images_h5_path}')
             serialise_h5(config)
 
     if config.use_dp:

--- a/train.py
+++ b/train.py
@@ -1,4 +1,4 @@
-import json, random, copy, sys
+import json, copy, os
 from tqdm import tqdm
 from collections import OrderedDict
 

--- a/utils.py
+++ b/utils.py
@@ -29,6 +29,9 @@ def parse_args():
     parser.add_argument('--seed', type=int, help='Seed to allow reproducibility.')
     parser.add_argument('--save-dir', type=str, help='Checkpoints directory.')
 
+    # for shadow model training
+    parser.add_argument('--shadow_training', action='store_true', default=False, help='Whether to train a shadow model or not (subsample providers).')
+
     # Experimental:
     parser.add_argument('--lora', action='store_true', default=False, help='Run LoRA.')
 
@@ -162,6 +165,7 @@ def load_config(args):
         config.model_name, config.dataset_name, f'_dp_C{config.dp_params.sensitivity:.1f}_e{config.dp_params.noise_multiplier:.3f}' if config.use_dp else '',
         '_lora' if config.lora else '', experiment_date
     )
+    config.shadow_training_providers_path = os.path.join(config.save_dir, f'shadow_training_providers_{config.experiment_name}.json')
 
     return config
 


### PR DESCRIPTION
I now have implemented the shadow model sampling. Please have a look, then we could add documentation afterwards.

It is quite simple, just some minor changes:
- In `train.py` I added another config param to allow for shadow_training and when it is set in expectation 50% of the providers are selected using coinflips (similar to LiRA attack) and the in_providers and out_providers are written to a json in the result_dir that has two keys: `{in_providers: list_of_in_providers, 'out_providers': list_of_out_providers}` . This is important so that we can later report together with the model which providers' data has been used.
- For the non-DP case, I just added an if statement to check if the flag for shadow_training is set and then in `build_utils.py` I have implemented a function named `build_dataset_of_subset_of_providers` that takes a list of provider names as input and then creates the dataset based on them.  In the non-DP setting we have one training_dataset and one train_loader in the end. (Basically, I just gather the indices of the documents of the in_providers and filter the dataset with that based on existing functions)
- In the DP case the modification is even simpler as we anyways create a separate dataloader for each provider in `train.py` . In that loop instead of looping over all providers I simply loop over the previously selected in_providers if the shadow_training flag is set.